### PR TITLE
double check with cpuArch

### DIFF
--- a/ps/Check UEFI PK, KEK, DB and DBX.ps1
+++ b/ps/Check UEFI PK, KEK, DB and DBX.ps1
@@ -48,15 +48,15 @@ try {
     $Is64bit = $true
     Write-Warning "Unable to determine system architecture, proceeding with defaults (x64).`n"
 }
-$arch = if (-not $IsArm -and $Is64bit -and $cpuArch -eq 9) {
-        "x64" # CPU arch x64 just to confirm
-    } elseif ($IsArm -and $Is64bit -and $cpuArch -eq 12) {
-        "arm64" # CPU arch ARM64 just to confirm
-    } elseif (-not $IsArm -and -not $Is64bit -and ($cpuArch -eq 0 -or $cpuArch -eq 9)) {
-        "x86" # CPU arch can be x86 or x64, but Windows/EFI arch is x86, thus the one we set here.
-    } elseif ($cpuArch -eq 5) {
+$arch = if ($Is64bit -and -not $IsArm -and $cpuArch -eq 9) { # CPU arch x64
+        "x64"
+    } elseif ($Is64bit -and $IsArm -and $cpuArch -eq 12) {   # CPU arch ARM64
+        "arm64"
+    } elseif (-not $Is64bit -and -not $IsArm -and ($cpuArch -eq 0 -or $cpuArch -eq 9)) {
+        "x86" # CPU arch can be x86 or x64, but Windows/EFI arch is x86, thus the one we need.
+    } elseif (-not $Is64bit -and $IsArm) { # cpu arch checked with $IsArm
         "arm"
-    } else {
+    } else { # any other unsupported CPU architecture
         "None: Error"
     }
 

--- a/ps/Check UEFI PK, KEK, DB and DBX.ps1
+++ b/ps/Check UEFI PK, KEK, DB and DBX.ps1
@@ -45,8 +45,9 @@ try {
     $Is64bit = [Environment]::Is64BitOperatingSystem
 } catch {
     $IsArm = $false
-    $Is64bit = $true
+    $Is64bit = $true    
     Write-Warning "Unable to determine system architecture, proceeding with defaults (x64).`n"
+    $cpuArch = 9 # default x64
 }
 $arch = if ($Is64bit -and -not $IsArm -and $cpuArch -eq 9) { # CPU arch x64
         "x64"
@@ -57,7 +58,7 @@ $arch = if ($Is64bit -and -not $IsArm -and $cpuArch -eq 9) { # CPU arch x64
     } elseif (-not $Is64bit -and $IsArm) { # cpu arch checked with $IsArm
         "arm"
     } else { # any other unsupported CPU architecture
-        "None: Error"
+        "unsupported"
     }
 
 Write-Host "Detected $arch UEFI architecture. Ensure that this is correct for valid DBX results.`n"
@@ -257,7 +258,7 @@ if ($arch -eq "x64") {
 } elseif ($arch -eq "arm") {
     Show-CheckDBX "2025-02-25 (v1.4.0) [$arch]  " "$PSScriptRoot\..\dbx_bin\arm_DBXUpdate_2025-02-25.bin"
 } else {
-     Write-Host "[$arch] not supported."
+     Write-Warning "[$arch] architecture."
 }
 
 $svn_latest_dbx = "10_14_25"

--- a/ps/Check UEFI PK, KEK, DB and DBX.ps1
+++ b/ps/Check UEFI PK, KEK, DB and DBX.ps1
@@ -242,6 +242,8 @@ function Show-CheckDBX {
     }
 }
 
+# select the proper bin file for the DBX Update.
+# files are copied from https://github.com/microsoft/secureboot_objects/tree/main/PostSignedObjects/DBX
 if ($arch -eq "x64") {
   # Show-CheckDBX "2023-03-14         " "$PSScriptRoot\..\dbx_bin\x64_DBXUpdate_2023-03-14.bin"
   # Show-CheckDBX "2023-05-09         " "$PSScriptRoot\..\dbx_bin\x64_DBXUpdate_2023-05-09.bin"

--- a/ps/Check UEFI PK, KEK, DB and DBX.ps1
+++ b/ps/Check UEFI PK, KEK, DB and DBX.ps1
@@ -45,7 +45,7 @@ try {
     $Is64bit = [Environment]::Is64BitOperatingSystem
 } catch {
     $IsArm = $false
-    $Is64bit = $true    
+    $Is64bit = $true
     Write-Warning "Unable to determine system architecture, proceeding with defaults (x64).`n"
     $cpuArch = 9 # default x64
 }
@@ -55,7 +55,7 @@ $arch = if ($Is64bit -and $cpuArch -eq 9) { # CPU arch x64
         "arm64"
     } elseif (-not $Is64bit -and ($cpuArch -eq 0 -or $cpuArch -eq 9)) {
         "x86" # CPU arch can be x86 or x64, but Windows/EFI arch is x86, thus the one we need.
-    } elseif (-not $Is64bit -and $IsArm) { # cpu arch check with $IsArm
+    } elseif (-not $Is64bit -and $IsArm) { # cpu arch check with $IsArm above
         "arm"
     } else { # any other unsupported CPU architecture
         "unsupported"

--- a/ps/Check UEFI PK, KEK, DB and DBX.ps1
+++ b/ps/Check UEFI PK, KEK, DB and DBX.ps1
@@ -52,7 +52,7 @@ $arch = if (-not $IsArm -and $Is64bit -and $cpuArch -eq 9) {
         "x64" # CPU arch x64 just to confirm
     } elseif ($IsArm -and $Is64bit -and $cpuArch -eq 12) {
         "arm64" # CPU arch ARM64 just to confirm
-    } elseif (-not $IsArm -and -not $Is64bit) {
+    } elseif (-not $IsArm -and -not $Is64bit -and ($cpuArch -eq 0 -or $cpuArch -eq 9)) {
         "x86" # CPU arch can be x86 or x64, but Windows/EFI arch is x86, thus the one we set here.
     } elseif ($cpuArch -eq 5) {
         "arm"
@@ -252,8 +252,10 @@ if ($arch -eq "x64") {
     Show-CheckDBX "2025-02-25 (v1.4.0) [$arch]" "$PSScriptRoot\..\dbx_bin\arm64_DBXUpdate_2025-02-25.bin"
 } elseif ($arch -eq "x86") {
     Show-CheckDBX "2025-10-14 (v1.6.0) [$arch]  " "$PSScriptRoot\..\dbx_bin\x86_DBXUpdate_2025-10-14.bin"
-} else {
+} elseif ($arch -eq "arm") {
     Show-CheckDBX "2025-02-25 (v1.4.0) [$arch]  " "$PSScriptRoot\..\dbx_bin\arm_DBXUpdate_2025-02-25.bin"
+} else {
+     Write-Host "[$arch] not supported."
 }
 
 $svn_latest_dbx = "10_14_25"

--- a/ps/Check UEFI PK, KEK, DB and DBX.ps1
+++ b/ps/Check UEFI PK, KEK, DB and DBX.ps1
@@ -40,7 +40,7 @@ try {
     if ($cpuArch -eq 5 -or $cpuArch -eq 12) {
         $IsArm = $true
     }
-    # Windows and UEFI bit-ness should always match on officially supported installs 
+    # Windows and UEFI bit-ness should always match on officially supported installs
     # since UEFI doesn't support cross-platform boot as of https://learn.microsoft.com/en-us/windows/deployment/windows-deployment-scenarios-and-tools#windows-support-for-uefi
     $Is64bit = [Environment]::Is64BitOperatingSystem
 } catch {

--- a/ps/Check UEFI PK, KEK, DB and DBX.ps1
+++ b/ps/Check UEFI PK, KEK, DB and DBX.ps1
@@ -51,7 +51,7 @@ try {
 }
 $arch = if ($Is64bit -and $cpuArch -eq 9) { # CPU arch x64
         "x64"
-    } elseif ($Is64bit -and $cpuArch -eq 12) {   # CPU arch ARM64
+    } elseif ($Is64bit -and $cpuArch -eq 12) { # CPU arch ARM64
         "arm64"
     } elseif (-not $Is64bit -and ($cpuArch -eq 0 -or $cpuArch -eq 9)) {
         "x86" # CPU arch can be x86 or x64, but Windows/EFI arch is x86, thus the one we need.

--- a/ps/Check UEFI PK, KEK, DB and DBX.ps1
+++ b/ps/Check UEFI PK, KEK, DB and DBX.ps1
@@ -49,13 +49,13 @@ try {
     Write-Warning "Unable to determine system architecture, proceeding with defaults (x64).`n"
     $cpuArch = 9 # default x64
 }
-$arch = if ($Is64bit -and -not $IsArm -and $cpuArch -eq 9) { # CPU arch x64
+$arch = if ($Is64bit -and $cpuArch -eq 9) { # CPU arch x64
         "x64"
-    } elseif ($Is64bit -and $IsArm -and $cpuArch -eq 12) {   # CPU arch ARM64
+    } elseif ($Is64bit -and $cpuArch -eq 12) {   # CPU arch ARM64
         "arm64"
-    } elseif (-not $Is64bit -and -not $IsArm -and ($cpuArch -eq 0 -or $cpuArch -eq 9)) {
+    } elseif (-not $Is64bit -and ($cpuArch -eq 0 -or $cpuArch -eq 9)) {
         "x86" # CPU arch can be x86 or x64, but Windows/EFI arch is x86, thus the one we need.
-    } elseif (-not $Is64bit -and $IsArm) { # cpu arch checked with $IsArm
+    } elseif (-not $Is64bit -and $IsArm) { # cpu arch check with $IsArm
         "arm"
     } else { # any other unsupported CPU architecture
         "unsupported"


### PR DESCRIPTION
- check the CPU arch before setting the Windows / UEFI arch to make the code more robust and skip any other unsupported [CPU architectures](https://learn.microsoft.com/en-us/windows/win32/cimwin32prov/win32-processor#properties) like ia64 (in case someone came to the idea of running the script on  some specific older systems)
- add inline documentation