### PR TITLE
Integrate StagedSVN check due to outdated MSFT dbx_info

### DIFF
--- a/ps/Check UEFI PK, KEK, DB and DBX.ps1
+++ b/ps/Check UEFI PK, KEK, DB and DBX.ps1
@@ -297,7 +297,13 @@ $StagedSVNbytes = [IO.File]::ReadAllBytes('C:\Windows\System32\SecureBootUpdates
 $svn_staged = Get-SVNfromDBX (Get-UEFIDatabaseSignatures -BytesIn $StagedSVNbytes)
 
 foreach ($key in $components.Keys) {
-    $name       = $components[$key].Name.PadRight($colWidth) + " : "
+    Write-Host -NoNewline "$($components[$key].Name.PadRight($colWidth)) : "
+
+    if (-not $svn_list.$key) {
+        Write-Host "Not applied" -ForegroundColor Red
+        continue
+    }
+
     $json       = $components[$key].JSON
     $current    = $svn_list.$key.Version
     $staged     = $svn_staged.$key.Version
@@ -306,7 +312,6 @@ foreach ($key in $components.Keys) {
     $isUpdated = ($current -ge $target)
     $color = if ($isUpdated) { "Green" } else { "Red" }
     $text = if ($isUpdated) { "$current" } else { "$current (Target: $target)" }
-    Write-Host -NoNewline $name
     Write-Host $text -ForegroundColor $color
 }
 

--- a/ps/Check UEFI PK, KEK, DB and DBX.ps1
+++ b/ps/Check UEFI PK, KEK, DB and DBX.ps1
@@ -288,14 +288,29 @@ $dbx_hashes -= $dbx_svns
 
 $svn_list = Get-SVNfromDBX $dbx_list
 
-Write-Host ("Windows Bootmgr SVN".PadRight($colWidth) + " : ") -NoNewline
+Write-Host ("Windows BootManager SVN".PadRight($colWidth) + " : ") -NoNewline
+
 if ($svn_list.BootMgr) {
+    $StagedSVNbytes = [IO.File]::ReadAllBytes('C:\Windows\System32\SecureBootUpdates\DBXUpdateSVN.bin')
+    $staged_svn = Get-SVNfromDBX (Get-UEFIDatabaseSignatures -BytesIn $StagedSVNbytes)
+
+    $svn_bootmgr_staged = $staged_svn.BootMgr.Version
     $svn_bootmgr_ver = $svn_list.BootMgr.Version
-    if ($svn_bootmgr_latest -and $svn_bootmgr_ver -ge $svn_bootmgr_latest) {
-        Write-Host $svn_bootmgr_ver -ForegroundColor Green
+
+    $target = if ($svn_bootmgr_latest -ge $svn_bootmgr_staged) {
+        $svn_bootmgr_latest
     } else {
-        Write-Host $svn_bootmgr_ver -ForegroundColor Red
+        $svn_bootmgr_staged
     }
+
+    $isUpdated = ($svn_bootmgr_ver -ge $target)
+    if ($isUpdated) {
+        $text = "$svn_bootmgr_ver"
+    } else {
+        $text = "$svn_bootmgr_ver (Latest $target)"
+    }
+
+    Write-Host $text -ForegroundColor $(if ($isUpdated) { 'Green' } else { 'Red' })
 } else {
     Write-Host 'None' -ForegroundColor Red
 }

--- a/ps/Check UEFI PK, KEK, DB and DBX.ps1
+++ b/ps/Check UEFI PK, KEK, DB and DBX.ps1
@@ -286,56 +286,28 @@ $dbx_certs = @($dbx_list | Where-Object { $_.SignatureType -eq 'EFI_CERT_X509_GU
 $dbx_svns = @($dbx_list | Where-Object { $_.SignatureType -eq 'EFI_CERT_SHA256_GUID' } | ForEach-Object { $_.SignatureList | Where-Object { $_.SignatureOwner -eq [guid]$SVN_OWNER_GUID } } | ForEach-Object { $_.SignatureData }).Count
 $dbx_hashes -= $dbx_svns
 
+$components = [ordered]@{
+    BootMgr = @{ Name="Windows Bootmgr SVN"; JSON=$svn_bootmgr_latest }
+    CDBoot  = @{ Name="Windows cdboot SVN"; JSON=$svn_cdboot_latest }
+    WDSMgFw = @{ Name="Windows wdsmgfw SVN"; JSON=$svn_wdsmgfw_latest }
+}
+
 $svn_list = Get-SVNfromDBX $dbx_list
+$StagedSVNbytes = [IO.File]::ReadAllBytes('C:\Windows\System32\SecureBootUpdates\DBXUpdateSVN.bin')
+$svn_staged = Get-SVNfromDBX (Get-UEFIDatabaseSignatures -BytesIn $StagedSVNbytes)
 
-Write-Host ("Windows BootManager SVN".PadRight($colWidth) + " : ") -NoNewline
+foreach ($key in $components.Keys) {
+    $name       = $components[$key].Name.PadRight($colWidth) + " : "
+    $json       = $components[$key].JSON
+    $current    = $svn_list.$key.Version
+    $staged     = $svn_staged.$key.Version
 
-if ($svn_list.BootMgr) {
-    $StagedSVNbytes = [IO.File]::ReadAllBytes('C:\Windows\System32\SecureBootUpdates\DBXUpdateSVN.bin')
-    $staged_svn = Get-SVNfromDBX (Get-UEFIDatabaseSignatures -BytesIn $StagedSVNbytes)
-
-    $svn_bootmgr_staged = $staged_svn.BootMgr.Version
-    $svn_bootmgr_ver = $svn_list.BootMgr.Version
-
-    $target = if ($svn_bootmgr_latest -ge $svn_bootmgr_staged) {
-        $svn_bootmgr_latest
-    } else {
-        $svn_bootmgr_staged
-    }
-
-    $isUpdated = ($svn_bootmgr_ver -ge $target)
-    if ($isUpdated) {
-        $text = "$svn_bootmgr_ver"
-    } else {
-        $text = "$svn_bootmgr_ver (Latest $target)"
-    }
-
-    Write-Host $text -ForegroundColor $(if ($isUpdated) { 'Green' } else { 'Red' })
-} else {
-    Write-Host 'None' -ForegroundColor Red
-}
-
-Write-Host ("Windows cdboot SVN".PadRight($colWidth) + " : ") -NoNewline
-if ($svn_list.CDBoot) {
-    $svn_cdboot_ver = $svn_list.CDBoot.Version
-    if ($svn_cdboot_latest -and $svn_cdboot_ver -ge $svn_cdboot_latest) {
-        Write-Host $svn_cdboot_ver -ForegroundColor Green
-    } else {
-        Write-Host $svn_cdboot_ver -ForegroundColor Red
-    }
-} else {
-    Write-Host 'None' -ForegroundColor Red
-}
-Write-Host ("Windows wdsmgfw SVN".PadRight($colWidth) + " : ") -NoNewline
-if ($svn_list.WDSMgFw) {
-    $svn_wdsmgfw_ver = $svn_list.WDSMgFw.Version
-    if ($svn_wdsmgfw_latest -and $svn_wdsmgfw_ver -ge $svn_wdsmgfw_latest) {
-        Write-Host $svn_wdsmgfw_ver -ForegroundColor Green
-    } else {
-        Write-Host $svn_wdsmgfw_ver -ForegroundColor Red
-    }
-} else {
-    Write-Host 'None' -ForegroundColor Red
+    $target = if ($json -ge $staged) { $json } else { $staged }
+    $isUpdated = ($current -ge $target)
+    $color = if ($isUpdated) { "Green" } else { "Red" }
+    $text = if ($isUpdated) { "$current" } else { "$current (Target: $target)" }
+    Write-Host -NoNewline $name
+    Write-Host $text -ForegroundColor $color
 }
 
 Write-Host ("Statistics".PadRight($colWidth) + " : $dbx_size Bytes, $dbx_hashes SHA256 hashes, $dbx_certs X.509 certs, $dbx_svns SVNs")


### PR DESCRIPTION
**Integrate StagedSVN check since [dbx_info_msft_latest.json](https://github.com/microsoft/secureboot_objects/blob/main/PreSignedObjects/DBX/dbx_info_msft_latest.json) is a month behind Windows Update rollout**

Example below, mainboard model: MS-7917 (Intel 4th/5th Gen)

Old script: SVN 7.0 in green but StagedSVN is already 8.0 since [April 14, 2026 (KB5083769)](https://support.microsoft.com/topic/april-14-2026-kb5083769-os-builds-26200-8246-and-26100-8246-22f90ae5-9f26-40ac-9134-6a586a71163b)
<img width="1920" height="790" alt="Screenshot (7)" src="https://github.com/user-attachments/assets/70cbef96-7e01-46fc-a53f-5856d3006db6" />

Updated script from the commit: SVN 7.0 in red and latest version as per StagedSVN in brackets. In case DBX info is ahead of staged, same procedure.
<img width="1920" height="981" alt="Screenshot (13)" src="https://github.com/user-attachments/assets/b33ec85b-0a9d-4c51-90c2-d3de0738e523" />

Updated script with SVN updated to "real" latest version 8.0. 
<img width="1920" height="982" alt="Screenshot (15)" src="https://github.com/user-attachments/assets/bfd69de5-168d-44d1-84c3-33afca7ed68e" />

