### PR TITLE
Use dynamic drive letter for EFI mountvol

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,30 +113,34 @@ To view the current Windows Secure Boot state, right-click `Check Windows state.
 Checking for Administrator permission...
 Running as administrator - continuing execution...
 
-Windows version: 25H2 (Build 26200.8246)
+Windows version: 25H2 (Build 26200.8457)
 
 UEFISecureBootEnabled    : 1
 AvailableUpdates         : 0x0000
 UEFICA2023Status         : Updated
 WindowsUEFICA2023Capable : Windows UEFI CA 2023 cert is in DB, system is starting from 2023 signed boot manager
 
+The EFI System Partition is not mounted. Mounting to S:.
+
 bootmgfw version         : 10.0.28000.322 (WinBuild.160101.0800)
-bootmgfw raw version     : 10.0.28000.322
+bootmgfw raw version     : 10.0.28000.326
 bootmgfw signature CA    : Windows UEFI CA 2023
 bootmgfw SVN             : 8.0
 
 bootmgr version          : 10.0.28000.322 (WinBuild.160101.0800)
-bootmgr raw version      : 10.0.28000.322
+bootmgr raw version      : 10.0.28000.326
 bootmgr signature CA     : Microsoft Windows Production PCA 2011
 bootmgr SVN              : 8.0
 
 memtest version          : 10.0.26100.1 (WinBuild.160101.0800)
-memtest raw version      : 10.0.26100.8115
+memtest raw version      : 10.0.26100.8457
 memtest signature CA     : Microsoft Windows Production PCA 2011
 
 Staged BootMgr SVN       : 8.0
 Staged CDBoot SVN        : 3.0
 Staged WDSMgFw SVN       : 3.0
+
+Cleaning up: Unmounting the EFI System Partition from S: because we mounted it.
 
 Press any key to continue . . .
 ```

--- a/ps/Check Windows state.ps1
+++ b/ps/Check Windows state.ps1
@@ -68,9 +68,8 @@ $mountedByUs = $false
 $targetDrive = $null
 
 # Check if the ESP is already mounted and mount if not already mounted
-$MountVolOutput = mountvol | Where-Object { $_.Trim() -ne "" }
-$LastLine = $MountVolOutput[-1].Trim()
-if ($LastLine -match 'EFI.*([A-Z]):\\$') {
+$ESPMountStatus = (mountvol | Out-String) -split "`r?`n" | Where-Object { $_ -match 'EFI' } | Select-Object -Last 1
+if ($ESPMountStatus -match '([A-Z]):\\') {
     $driveLetter = $Matches[1]
     $targetDrive = "${driveLetter}:"
     Write-Host "The EFI System Partition is already mounted at ${targetDrive}.`n" -ForegroundColor Cyan

--- a/ps/Check Windows state.ps1
+++ b/ps/Check Windows state.ps1
@@ -46,9 +46,16 @@ function Get-AuthenticodeSignatureSignerCertificateIssuerCN {
 }
 
 function Get-UnassignedDriveLetter {
-    $alphabet = 65..90 | ForEach-Object { [char]$_ }
     $used = Get-PSDrive -PSProvider FileSystem | Select-Object -ExpandProperty Name
-    $free = $alphabet | Where-Object { $_ -notin $used }
+    
+    # Use drive S: if it is available
+    if ('S' -notin $used) {
+        return 'S:'
+    }
+
+    # Fallback: Search for an unassigned letter from the middle of the alphabet
+    $alphabet = 68..90 | ForEach-Object { [char]$_ } # Search from D to Z
+    $free = @($alphabet | Where-Object { $_ -notin $used })
     if ($free.Count -eq 0) {
         throw "No free drive letters to mount safely to."
     }
@@ -56,56 +63,85 @@ function Get-UnassignedDriveLetter {
     return "${target}:"
 }
 
-$targetDrive = Get-UnassignedDriveLetter
-$efiBootPath = "$targetDrive\EFI\Microsoft\Boot"
+# Track our mounting state
+$mountedByUs = $false
+$targetDrive = $null
 
-mountvol $targetDrive /s
+# Check if the ESP is already mounted and mount if not already mounted
+$MountVolOutput = mountvol | Where-Object { $_.Trim() -ne "" }
+$LastLine = $MountVolOutput[-1].Trim()
+if ($LastLine -match 'EFI.*([A-Z]):\\$') {
+    $driveLetter = $Matches[1]
+    $targetDrive = "${driveLetter}:"
+    Write-Host "The EFI System Partition is already mounted at ${targetDrive}.`n" -ForegroundColor Cyan
+} else {
+    $targetDrive = Get-UnassignedDriveLetter
+    Write-Host "The EFI System Partition is not mounted. Mounting to ${targetDrive}.`n" -ForegroundColor Yellow
+    & mountvol "${targetDrive}" /S
+    $mountedByUs = $true
+}
 
-$bootmgfw_verinfo = (Get-Item -Path "$efiBootPath\bootmgfw.efi").VersionInfo
-$bootmgfw_sigCA_name = Get-AuthenticodeSignatureSignerCertificateIssuerCN "$efiBootPath\bootmgfw.efi"
-$bootmgfw_svn_ver = Get-BootMgrSecurityVersion -Path "$efiBootPath\bootmgfw.efi"
+try {
 
-$bootmgr_verinfo = (Get-Item -Path "$efiBootPath\bootmgr.efi").VersionInfo
-$bootmgr_sigCA_name = Get-AuthenticodeSignatureSignerCertificateIssuerCN "$efiBootPath\bootmgr.efi"
-$bootmgr_svn_ver = Get-BootMgrSecurityVersion -Path "$efiBootPath\bootmgr.efi"
+    $efiBootPath = "${targetDrive}\EFI\Microsoft\Boot"
 
-$memtest_verinfo = (Get-Item -Path "$efiBootPath\memtest.efi").VersionInfo
-$memtest_sigCA_name = Get-AuthenticodeSignatureSignerCertificateIssuerCN "$efiBootPath\memtest.efi"
+    $bootmgfw_verinfo = (Get-Item -Path "$efiBootPath\bootmgfw.efi").VersionInfo
+    $bootmgfw_sigCA_name = Get-AuthenticodeSignatureSignerCertificateIssuerCN "$efiBootPath\bootmgfw.efi"
+    $bootmgfw_svn_ver = Get-BootMgrSecurityVersion -Path "$efiBootPath\bootmgfw.efi"
 
-mountvol $targetDrive /d
+    $bootmgr_verinfo = (Get-Item -Path "$efiBootPath\bootmgr.efi").VersionInfo
+    $bootmgr_sigCA_name = Get-AuthenticodeSignatureSignerCertificateIssuerCN "$efiBootPath\bootmgr.efi"
+    $bootmgr_svn_ver = Get-BootMgrSecurityVersion -Path "$efiBootPath\bootmgr.efi"
 
-$bootmgfw_ver = $bootmgfw_verinfo.FileVersion
-$bootmgfw_ver_raw = $bootmgfw_verinfo.FileVersionRaw
-Write-Host "bootmgfw version         : $bootmgfw_ver"
-Write-Host "bootmgfw raw version     : $bootmgfw_ver_raw"
-Write-Host "bootmgfw signature CA    : $bootmgfw_sigCA_name"
-Write-Host "bootmgfw SVN             : $bootmgfw_svn_ver"
+    $memtest_verinfo = (Get-Item -Path "$efiBootPath\memtest.efi").VersionInfo
+    $memtest_sigCA_name = Get-AuthenticodeSignatureSignerCertificateIssuerCN "$efiBootPath\memtest.efi"
 
-Write-Host ""
+    $bootmgfw_ver = $bootmgfw_verinfo.FileVersion
+    $bootmgfw_ver_raw = $bootmgfw_verinfo.FileVersionRaw
+    Write-Host "bootmgfw version         : $bootmgfw_ver"
+    Write-Host "bootmgfw raw version     : $bootmgfw_ver_raw"
+    Write-Host "bootmgfw signature CA    : $bootmgfw_sigCA_name"
+    Write-Host "bootmgfw SVN             : $bootmgfw_svn_ver"
 
-$bootmgr_ver = $bootmgr_verinfo.FileVersion
-$bootmgr_ver_raw = $bootmgr_verinfo.FileVersionRaw
-Write-Host "bootmgr version          : $bootmgr_ver"
-Write-Host "bootmgr raw version      : $bootmgr_ver_raw"
-Write-Host "bootmgr signature CA     : $bootmgr_sigCA_name"
-Write-Host "bootmgr SVN              : $bootmgr_svn_ver"
+    Write-Host ""
 
-Write-Host ""
+    $bootmgr_ver = $bootmgr_verinfo.FileVersion
+    $bootmgr_ver_raw = $bootmgr_verinfo.FileVersionRaw
+    Write-Host "bootmgr version          : $bootmgr_ver"
+    Write-Host "bootmgr raw version      : $bootmgr_ver_raw"
+    Write-Host "bootmgr signature CA     : $bootmgr_sigCA_name"
+    Write-Host "bootmgr SVN              : $bootmgr_svn_ver"
 
-$memtest_ver = $memtest_verinfo.FileVersion
-$memtest_ver_raw = $memtest_verinfo.FileVersionRaw
-Write-Host "memtest version          : $memtest_ver"
-Write-Host "memtest raw version      : $memtest_ver_raw"
-Write-Host "memtest signature CA     : $memtest_sigCA_name"
+    Write-Host ""
 
-Write-Host ""
+    $memtest_ver = $memtest_verinfo.FileVersion
+    $memtest_ver_raw = $memtest_verinfo.FileVersionRaw
+    Write-Host "memtest version          : $memtest_ver"
+    Write-Host "memtest raw version      : $memtest_ver_raw"
+    Write-Host "memtest signature CA     : $memtest_sigCA_name"
 
-Import-Module -Force "$PSScriptRoot\Get-UEFIDatabaseSignatures.psm1"
-Import-Module -Force "$PSScriptRoot\Get-SVNfromDBX.psm1"
+    Write-Host ""
 
-$StagedSVNbytes = [IO.File]::ReadAllBytes('C:\Windows\System32\SecureBootUpdates\DBXUpdateSVN.bin')
-$staged_svn = Get-SVNfromDBX (Get-UEFIDatabaseSignatures -BytesIn $StagedSVNbytes)
+    Import-Module -Force "$PSScriptRoot\Get-UEFIDatabaseSignatures.psm1"
+    Import-Module -Force "$PSScriptRoot\Get-SVNfromDBX.psm1"
 
-Write-Host "Staged BootMgr SVN       : $($staged_svn.BootMgr.Version)"
-Write-Host "Staged CDBoot SVN        : $($staged_svn.CDBoot.Version)"
-Write-Host "Staged WDSMgFw SVN       : $($staged_svn.WDSMgFw.Version)"
+    $StagedSVNbytes = [IO.File]::ReadAllBytes('C:\Windows\System32\SecureBootUpdates\DBXUpdateSVN.bin')
+    $staged_svn = Get-SVNfromDBX (Get-UEFIDatabaseSignatures -BytesIn $StagedSVNbytes)
+
+    Write-Host "Staged BootMgr SVN       : $($staged_svn.BootMgr.Version)"
+    Write-Host "Staged CDBoot SVN        : $($staged_svn.CDBoot.Version)"
+    Write-Host "Staged WDSMgFw SVN       : $($staged_svn.WDSMgFw.Version)"
+
+    Write-Host ""
+
+} catch {
+    Write-Error "An exception has occured: $_"
+} finally {
+    # Guaranteed cleanup
+    if ($mountedByUs) {
+        Write-Host "Cleaning up: Unmounting the EFI System Partition from ${targetDrive} because we mounted it." -ForegroundColor Yellow
+        & mountvol "${targetDrive}" /D
+    } else {
+        Write-Host "Cleanup skipped: The EFI System Partition was already mounted before we started." -ForegroundColor Cyan
+    }
+}

--- a/ps/Check Windows state.ps1
+++ b/ps/Check Windows state.ps1
@@ -45,20 +45,34 @@ function Get-AuthenticodeSignatureSignerCertificateIssuerCN {
     $Issuers
 }
 
-mountvol s: /s
+function Get-UnassignedDriveLetter {
+    $alphabet = 65..90 | ForEach-Object { [char]$_ }
+    $used = Get-PSDrive -PSProvider FileSystem | Select-Object -ExpandProperty Name
+    $free = $alphabet | Where-Object { $_ -notin $used }
+    if ($free.Count -eq 0) {
+        throw "No free drive letters to mount safely to."
+    }
+    $target = $free[[int]($free.Count / 2)]
+    return "${target}:"
+}
 
-$bootmgfw_verinfo = (Get-Item -Path S:\EFI\Microsoft\Boot\bootmgfw.efi).VersionInfo
-$bootmgfw_sigCA_name = Get-AuthenticodeSignatureSignerCertificateIssuerCN 'S:\EFI\Microsoft\Boot\bootmgfw.efi'
-$bootmgfw_svn_ver = Get-BootMgrSecurityVersion -Path 'S:\EFI\Microsoft\Boot\bootmgfw.efi'
+$targetDrive = Get-UnassignedDriveLetter
+$efiBootPath = "$targetDrive\EFI\Microsoft\Boot"
 
-$bootmgr_verinfo = (Get-Item -Path S:\EFI\Microsoft\Boot\bootmgr.efi).VersionInfo
-$bootmgr_sigCA_name = Get-AuthenticodeSignatureSignerCertificateIssuerCN 'S:\EFI\Microsoft\Boot\bootmgr.efi'
-$bootmgr_svn_ver = Get-BootMgrSecurityVersion -Path 'S:\EFI\Microsoft\Boot\bootmgr.efi'
+mountvol $targetDrive /s
 
-$memtest_verinfo = (Get-Item -Path S:\EFI\Microsoft\Boot\memtest.efi).VersionInfo
-$memtest_sigCA_name = Get-AuthenticodeSignatureSignerCertificateIssuerCN 'S:\EFI\Microsoft\Boot\memtest.efi'
+$bootmgfw_verinfo = (Get-Item -Path "$efiBootPath\bootmgfw.efi").VersionInfo
+$bootmgfw_sigCA_name = Get-AuthenticodeSignatureSignerCertificateIssuerCN "$efiBootPath\bootmgfw.efi"
+$bootmgfw_svn_ver = Get-BootMgrSecurityVersion -Path "$efiBootPath\bootmgfw.efi"
 
-mountvol s: /d
+$bootmgr_verinfo = (Get-Item -Path "$efiBootPath\bootmgr.efi").VersionInfo
+$bootmgr_sigCA_name = Get-AuthenticodeSignatureSignerCertificateIssuerCN "$efiBootPath\bootmgr.efi"
+$bootmgr_svn_ver = Get-BootMgrSecurityVersion -Path "$efiBootPath\bootmgr.efi"
+
+$memtest_verinfo = (Get-Item -Path "$efiBootPath\memtest.efi").VersionInfo
+$memtest_sigCA_name = Get-AuthenticodeSignatureSignerCertificateIssuerCN "$efiBootPath\memtest.efi"
+
+mountvol $targetDrive /d
 
 $bootmgfw_ver = $bootmgfw_verinfo.FileVersion
 $bootmgfw_ver_raw = $bootmgfw_verinfo.FileVersionRaw

--- a/ps/Find-EfiFilesRevokedByDbx.ps1
+++ b/ps/Find-EfiFilesRevokedByDbx.ps1
@@ -141,9 +141,16 @@ function Get-EfiFilesUnderPaths {
 }
 
 function Get-UnassignedDriveLetter {
-    $alphabet = 65..90 | ForEach-Object { [char]$_ }
     $used = Get-PSDrive -PSProvider FileSystem | Select-Object -ExpandProperty Name
-    $free = $alphabet | Where-Object { $_ -notin $used }
+    
+    # Use drive S: if it is available
+    if ('S' -notin $used) {
+        return 'S:'
+    }
+
+    # Fallback: Search for an unassigned letter from the middle of the alphabet
+    $alphabet = 68..90 | ForEach-Object { [char]$_ } # Search from D to Z
+    $free = @($alphabet | Where-Object { $_ -notin $used })
     if ($free.Count -eq 0) {
         throw "No free drive letters to mount safely to."
     }
@@ -151,25 +158,30 @@ function Get-UnassignedDriveLetter {
     return "${target}:"
 }
 
-$targetDrive = Get-UnassignedDriveLetter
+# Track our mounting state
+$mountedByUs = $false
+$targetDrive = $null
+
+# Check if the ESP is already mounted and mount if not already mounted
+$ESPMountStatus = (mountvol | Out-String) -split "`r?`n" | Where-Object { $_ -match 'EFI' } | Select-Object -Last 1
+if ($ESPMountStatus -match '([A-Z]):\\') {
+    $driveLetter = $Matches[1]
+    $targetDrive = "${driveLetter}:"
+    Write-Host "The EFI System Partition is already mounted at ${targetDrive}.`n" -ForegroundColor Cyan
+} else {
+    $targetDrive = Get-UnassignedDriveLetter
+    Write-Host "The EFI System Partition is not mounted. Mounting to ${targetDrive}.`n" -ForegroundColor Yellow
+    & mountvol "${targetDrive}" /S
+    $mountedByUs = $true
+}
 
 # Build scan roots
 $scanRoots = New-Object System.Collections.Generic.List[string]
-
-$didMountEsp = $false
-if ($ScanESP) {
-    try {
-        mountvol $targetDrive /s | Out-Null
-        $didMountEsp = $true
-        $scanRoots.Add("${targetDrive}\") | Out-Null
-    } catch {
-        Write-Warning "Could not mount ESP to $targetDrive. Run as Administrator? Continuing..."
-    }
-}
+$scanRoots.Add("${targetDrive}") | Out-Null
 
 if ($ScanDefaultPaths) {
     # Common locations where EFI binaries may exist on the OS volume.
-    $scanRoots.Add("$env:SystemRoot\Boot\EFI") | Out-Null
+    $scanRoots.Add("$env:SystemRoot\Boot") | Out-Null # WIN11-25H2 \EFI + \EFI_EX
     $scanRoots.Add("$env:SystemDrive\EFI") | Out-Null
     $scanRoots.Add("$env:SystemDrive\Boot") | Out-Null
 }
@@ -264,6 +276,10 @@ foreach ($file in $efiFiles) {
 Write-Host ""
 Write-Host ("Scan complete. Warnings: {0}" -f $warnCount) -ForegroundColor Cyan
 
-if ($didMountEsp) {
-    try { mountvol $targetDrive /d | Out-Null } catch {}
+# Guaranteed cleanup
+if ($mountedByUs) {
+    Write-Host "Cleaning up: Unmounting the EFI System Partition from ${targetDrive} because we mounted it." -ForegroundColor Yellow
+    & mountvol "${targetDrive}" /D
+} else {
+    Write-Host "Cleanup skipped: The EFI System Partition was already mounted before we started." -ForegroundColor Cyan
 }

--- a/ps/Find-EfiFilesRevokedByDbx.ps1
+++ b/ps/Find-EfiFilesRevokedByDbx.ps1
@@ -9,7 +9,7 @@ param(
     # Root directories to scan for .efi files (optional)
     [string[]] $Paths,
 
-    # If set, will mount ESP to S: (mountvol s: /s) and scan it (default: true)
+    # If set, will mount ESP to an unassigned drive letter: (mountvol {letter}: /s) and scan it (default: true)
     [switch] $ScanESP = $true,
 
     # Helper flag: scan common OS paths too (default: false)
@@ -140,17 +140,30 @@ function Get-EfiFilesUnderPaths {
     $all
 }
 
+function Get-UnassignedDriveLetter {
+    $alphabet = 65..90 | ForEach-Object { [char]$_ }
+    $used = Get-PSDrive -PSProvider FileSystem | Select-Object -ExpandProperty Name
+    $free = $alphabet | Where-Object { $_ -notin $used }
+    if ($free.Count -eq 0) {
+        throw "No free drive letters to mount safely to."
+    }
+    $target = $free[[int]($free.Count / 2)]
+    return "${target}:"
+}
+
+$targetDrive = Get-UnassignedDriveLetter
+
 # Build scan roots
 $scanRoots = New-Object System.Collections.Generic.List[string]
 
 $didMountEsp = $false
 if ($ScanESP) {
     try {
-        mountvol s: /s | Out-Null
+        mountvol $targetDrive /s | Out-Null
         $didMountEsp = $true
-        $scanRoots.Add('S:\') | Out-Null
+        $scanRoots.Add("${targetDrive}\") | Out-Null
     } catch {
-        Write-Warning "Could not mount ESP to S:. Run as Administrator? Continuing..."
+        Write-Warning "Could not mount ESP to $targetDrive. Run as Administrator? Continuing..."
     }
 }
 
@@ -213,26 +226,26 @@ foreach ($file in $efiFiles) {
         }
     } catch {}
 
-    $matches = @()
+    $efiMatches = @()
 
     foreach ($set in $revocationSets) {
         # Hash match
         if ($fileSha -and $set.Sha256Set.Contains($fileSha)) {
-            $matches += [PSCustomObject]@{ Source=$set.Name; Type='Hash'; Detail='SHA256(Authenticode) matches revocation list' }
+            $efiMatches += [PSCustomObject]@{ Source=$set.Name; Type='Hash'; Detail='SHA256(Authenticode) matches revocation list' }
         }
 
         # Cert match
         if ($signerThumbprints.Count -gt 0 -$set.X509DerSet.Count -gt 0) {
             foreach ($derHex in $signerThumbprints) {
                 if ($set.X509DerSet.Contains($derHex)) {
-                    $matches += [PSCustomObject]@{ Source=$set.Name; Type='SignerCert'; Detail='Signer certificate DER matches DBX X509 revocation' }
+                    $efiMatches += [PSCustomObject]@{ Source=$set.Name; Type='SignerCert'; Detail='Signer certificate DER matches DBX X509 revocation' }
                     break
                 }
             }
         }
     }
 
-    if ($matches.Count -gt 0) {
+    if ($efiMatches.Count -gt 0) {
         $warnCount++
         Write-Host ""
         Write-Host "WARNING: EFI file matches revocation list(s)" -ForegroundColor Yellow
@@ -242,7 +255,7 @@ foreach ($file in $efiFiles) {
             Write-Host ("  Signer thumbprint(s): {0}" -f ($signerThumbprints -join ', '))
         }
 
-        foreach ($m in $matches) {
+        foreach ($m in $efiMatches) {
             Write-Host ("  Match: [{0}] {1} - {2}" -f $m.Source, $m.Type, $m.Detail) -ForegroundColor Yellow
         }
     }
@@ -252,5 +265,5 @@ Write-Host ""
 Write-Host ("Scan complete. Warnings: {0}" -f $warnCount) -ForegroundColor Cyan
 
 if ($didMountEsp) {
-    try { mountvol s: /d | Out-Null } catch {}
+    try { mountvol $targetDrive /d | Out-Null } catch {}
 }


### PR DESCRIPTION
Hardcoded EFI mount to **S:** caused an unintended application crash/data loss when already in use by an external SSD. 
**S:** is [not commonly assigned](https://en.wikipedia.org/wiki/Drive_letter_assignment#Common_assignments), that’s why I have it in use.