### PR TITLE
Improve Device overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,7 @@ Double-click `Show Secure Boot update events.cmd` to display all the Secure Boot
 To view the current Windows Secure Boot state, right-click `Check Windows state.cmd` and *Run as administrator*. The output will be similar to the following:
 
 ```
-
-Windows version: 25H2 (Build 26200.8457)
+Windows version          : Windows 11 - 25H2 (Build 26200.8457)
 
 UEFISecureBootEnabled    : 1
 AvailableUpdates         : 0x0000

--- a/ps/Check UEFI PK, KEK, DB and DBX.ps1
+++ b/ps/Check UEFI PK, KEK, DB and DBX.ps1
@@ -18,15 +18,9 @@ if (-not ((Test-Path -Path "$PSScriptRoot\Check-Dbx-Simplified.ps1" -PathType Le
 }
 
 # Print computer info
-Get-Date -Format 'dd MMMM yyyy'
-$computer = Get-CimInstance -ClassName Win32_ComputerSystem
-$bios = Get-CimInstance -ClassName Win32_BIOS
-"Manufacturer: " + $computer.Manufacturer
-"Model: " + $computer.Model
-$biosinfo = $bios.Manufacturer , $bios.Name , $bios.SMBIOSBIOSVersion , $bios.Version -join ", "
-"BIOS: " + $biosinfo
-$v = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion'
-"Windows version: {0} (Build {1}.{2})`n" -f $v.DisplayVersion, $v.CurrentBuildNumber, $v.UBR
+Import-Module $PSScriptRoot\Get-SystemOverview.psm1 -Force
+Show-DeviceOverview
+Write-Host
 
 # Check architecture
 $IsArm = $false

--- a/ps/Check UEFI PK, KEK, DB and DBX.ps1
+++ b/ps/Check UEFI PK, KEK, DB and DBX.ps1
@@ -41,7 +41,7 @@ try {
     $cpuArch = 9 # default x64
 }
 $arch = if ($Is64bit -and $cpuArch -eq 9) { # CPU arch x64
-        "x64"
+        "amd64"
     } elseif ($Is64bit -and $cpuArch -eq 12) { # CPU arch ARM64
         "arm64"
     } elseif (-not $Is64bit -and ($cpuArch -eq 0 -or $cpuArch -eq 9)) {
@@ -52,7 +52,7 @@ $arch = if ($Is64bit -and $cpuArch -eq 9) { # CPU arch x64
         "unsupported"
     }
 
-Write-Host "Detected $arch UEFI architecture. Ensure that this is correct for valid DBX results.`n"
+Write-Host "Detected $(Resolve-ArchName($arch)) UEFI architecture. Ensure that this is correct for valid DBX results.`n"
 
 # Check for Secure Boot status
 Write-Host "Secure Boot status: " -NoNewLine
@@ -246,20 +246,20 @@ function Show-CheckDBX {
 
 # select the proper bin file for the DBX Update.
 # files are copied from https://github.com/microsoft/secureboot_objects/tree/main/PostSignedObjects/DBX
-if ($arch -eq "x64") {
+if ($arch -eq "amd64") {
   # Show-CheckDBX "2023-03-14         " "$PSScriptRoot\..\dbx_bin\x64_DBXUpdate_2023-03-14.bin"
   # Show-CheckDBX "2023-05-09         " "$PSScriptRoot\..\dbx_bin\x64_DBXUpdate_2023-05-09.bin"
   # Show-CheckDBX "2025-01-14 (v1.3.1)" "$PSScriptRoot\..\dbx_bin\x64_DBXUpdate_2025-01-14.bin"
   # Show-CheckDBX "2025-06-11 (v1.5.1)" "$PSScriptRoot\..\dbx_bin\x64_DBXUpdate_2025-06-11.bin"
-    Show-CheckDBX "2025-10-14 (v1.6.0) [$arch]" "$PSScriptRoot\..\dbx_bin\x64_DBXUpdate_2025-10-14.bin"
+    Show-CheckDBX "2025-10-14 (v1.6.0) [$($arch.ToUpper())]" "$PSScriptRoot\..\dbx_bin\x64_DBXUpdate_2025-10-14.bin"
 } elseif ($arch -eq "arm64") {
-    Show-CheckDBX "2025-02-25 (v1.4.0) [$arch]" "$PSScriptRoot\..\dbx_bin\arm64_DBXUpdate_2025-02-25.bin"
+    Show-CheckDBX "2025-02-25 (v1.4.0) [$($arch.ToUpper())]" "$PSScriptRoot\..\dbx_bin\arm64_DBXUpdate_2025-02-25.bin"
 } elseif ($arch -eq "x86") {
-    Show-CheckDBX "2025-10-14 (v1.6.0) [$arch]" "$PSScriptRoot\..\dbx_bin\x86_DBXUpdate_2025-10-14.bin"
+    Show-CheckDBX "2025-10-14 (v1.6.0) [$($arch.ToUpper())]" "$PSScriptRoot\..\dbx_bin\x86_DBXUpdate_2025-10-14.bin"
 } elseif ($arch -eq "arm") {
-    Show-CheckDBX "2025-02-25 (v1.4.0) [$arch]" "$PSScriptRoot\..\dbx_bin\arm_DBXUpdate_2025-02-25.bin"
+    Show-CheckDBX "2025-02-25 (v1.4.0) [$($arch.ToUpper())]" "$PSScriptRoot\..\dbx_bin\arm_DBXUpdate_2025-02-25.bin"
 } else {
-     Write-Warning "[$arch] architecture."
+    Write-Warning "[$($arch.ToUpper())] architecture."
 }
 Show-CheckDBX "Current Windows staged" "C:\Windows\System32\SecureBootUpdates\dbxupdate.bin"
 

--- a/ps/Check Windows state.ps1
+++ b/ps/Check Windows state.ps1
@@ -8,8 +8,8 @@ if (-NOT ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdent
 }
 
 # Print computer info
-$v = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion'
-"Windows version: {0} (Build {1}.{2})`n" -f $v.DisplayVersion, $v.CurrentBuildNumber, $v.UBR
+Import-Module $PSScriptRoot\Get-SystemOverview.psm1 -Force
+"Windows version          : " + ((Show-WindowsVersion) -replace '^.*:\s*') + "`n"
 
 Write-Host "UEFISecureBootEnabled    :" (Get-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Control\SecureBoot\State).UEFISecureBootEnabled
 "AvailableUpdates         : 0x{0:X4}" -f (Get-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Control\SecureBoot).AvailableUpdates

--- a/ps/Get-SystemOverview.psm1
+++ b/ps/Get-SystemOverview.psm1
@@ -17,6 +17,18 @@ function Get-WindowsVersionFromBuild([int]$Build) {
     }
 }
 
+function Resolve-ArchName {
+    param([string]$Arch)
+
+    switch ($Arch.ToUpper()) {
+        "AMD64" { "AMD64/X64" }
+        "ARM"   { "ARM" }
+        "ARM64" { "ARM64/AARCH64" }
+        "X86"   { "X86/IA32" }
+        default { $Arch }
+    }
+}
+
 function Format-Set($Values) {
 
     # Filter out duplicates and junk
@@ -47,7 +59,6 @@ function Format-DeviceModel([string[]]$Values) {
     $result = if ($t1) { @($t1) + @($t2) } else { @($t3) }
     $result -join ' - '
 }
-
 
 function Show-WindowsVersion {
     $windows = Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion"
@@ -84,7 +95,7 @@ function Show-Device {
             $device.OEMModelSKU
             $device.OEMModelBaseBoardVersion
         )),
-        $device.OSArchitecture
+        (Resolve-ArchName $device.OSArchitecture)
         
     # Firmware
     "FW : {0} - {1} - {2}" -f `
@@ -96,4 +107,5 @@ function Show-Device {
 Export-ModuleMember -Function `
     Spacer,
     Show-WindowsVersion,
-    Show-DeviceOverview
+    Show-DeviceOverview,
+    Resolve-ArchName

--- a/ps/Get-SystemOverview.psm1
+++ b/ps/Get-SystemOverview.psm1
@@ -2,7 +2,7 @@
 # Repository https://github.com/cjee21/Check-UEFISecureBootVariables
 
 function Spacer() {
-    Write-Host ("-" * 45)
+    Write-Host ("-" * 60)
 }
 
 function Get-WindowsVersionFromBuild([int]$Build) {
@@ -35,6 +35,7 @@ function Format-Set($Values) {
     $clean = $Values | Where-Object {
         $_ -and
         $_ -notmatch "to be filled by o\.e\.m\." -and
+        $_ -notmatch "default string" -and
         $_ -ne "1.0" # Only applied to hardware, firmware can be '1.0'
     } | Select-Object -Unique
 

--- a/ps/Get-SystemOverview.psm1
+++ b/ps/Get-SystemOverview.psm1
@@ -1,0 +1,99 @@
+# Created by github.com/jcoester
+# Repository https://github.com/cjee21/Check-UEFISecureBootVariables
+
+function Spacer() {
+    Write-Host ("-" * 45)
+}
+
+function Get-WindowsVersionFromBuild([int]$Build) {
+
+    # See https://en.wikipedia.org/wiki/List_of_Microsoft_Windows_versions
+    switch ($Build) {
+        { $_ -ge 22000 } { return "11" }
+        { $_ -ge 10240 } { return "10" }
+        { $_ -ge 9600 }  { return "8.1" }
+        { $_ -ge 9200 }  { return "8" }
+        default          { return "" }
+    }
+}
+
+function Format-Set($Values) {
+
+    # Filter out duplicates and junk
+    $clean = $Values | Where-Object {
+        $_ -and
+        $_ -notmatch "to be filled by o\.e\.m\." -and
+        $_ -ne "1.0" # Only applied to hardware, firmware can be '1.0'
+    } | Select-Object -Unique
+
+    # Filter out substrings of others
+    foreach ($v in @($clean)) {
+        if ($clean | Where-Object { $_ -ne $v -and $_ -like "*$v*" }) {
+            $clean = $clean -ne $v
+        }
+    }
+
+    $clean
+}
+
+function Format-DeviceModel([string[]]$Values) {
+
+    # Build three tiers, from most specific to most generic
+    $t1 = Format-Set $Values[0,1] # OEMModelNumber, OEMModelBaseBoard
+    $t2 = Format-Set $Values[2,3] # OEMModelSystemFamily, OEMModelSystemVersion
+    $t3 = Format-Set $Values[4,5] # OEMModelSKU, OEMModelBaseBoardVersion
+
+    # T1 and T2 always, T3 as fallback
+    $result = if ($t1) { @($t1) + @($t2) } else { @($t3) }
+    $result -join ' - '
+}
+
+
+function Show-WindowsVersion {
+    $windows = Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion"
+    "OS : Windows {0} - {1} (Build {2}.{3})" -f `
+        (Get-WindowsVersionFromBuild ([int]$windows.CurrentBuildNumber)),
+        $windows.DisplayVersion,
+        $windows.CurrentBuildNumber,
+        $windows.UBR
+}
+
+function Show-DeviceOverview {
+    (Get-Date).ToString('dd MMM yyyy')
+    Spacer
+    Show-Device
+    Show-WindowsVersion
+}
+
+function Show-Device {
+    # Show Secure Boot related device hardware and firmware info
+    $device  = Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\SecureBoot\Servicing\DeviceAttributes"
+
+    # Hardware
+    "HW : {0} - {1} - {2}" -f `
+        ((Format-Set @(
+            $device.OEMName
+            $device.OEMManufacturerName
+            $device.BaseBoardManufacturer
+        )) -join " - "),
+        (Format-DeviceModel @(
+            $device.OEMModelNumber    
+            $device.OEMModelBaseBoard
+            $device.OEMModelSystemFamily
+            $device.OEMModelSystemVersion
+            $device.OEMModelSKU
+            $device.OEMModelBaseBoardVersion
+        )),
+        $device.OSArchitecture
+        
+    # Firmware
+    "FW : {0} - {1} - {2}" -f `
+        $device.FirmwareManufacturer,
+        $device.FirmwareVersion,
+        ([datetime]$device.FirmwareReleaseDate).ToString('dd MMM yyyy')
+}
+
+Export-ModuleMember -Function `
+    Spacer,
+    Show-WindowsVersion,
+    Show-DeviceOverview

--- a/ps/Get-SystemOverview.psm1
+++ b/ps/Get-SystemOverview.psm1
@@ -31,13 +31,16 @@ function Resolve-ArchName {
 
 function Format-Set($Values) {
 
-    # Filter out duplicates and junk
-    $clean = $Values | Where-Object {
-        $_ -and
-        $_ -notmatch "to be filled by o\.e\.m\." -and
-        $_ -notmatch "default string" -and
-        $_ -ne "1.0" # Only applied to hardware, firmware can be '1.0'
-    } | Select-Object -Unique
+    $Exclude = @(
+        'Default String'
+        'System Manufacturer'
+        'System Product Name'
+        'System Version'
+        'To Be Filled By O.E.M.'
+    )
+
+    # Filter out empty, exclude list, duplications. Return most specific (first of given set)
+    $clean = $Values | Where-Object { $_ -and $_ -notin $Exclude } | Select-Object -Unique
 
     # Filter out substrings of others
     foreach ($v in @($clean)) {
@@ -46,18 +49,19 @@ function Format-Set($Values) {
         }
     }
 
-    $clean
+    $clean | Select-Object -First 1 
 }
 
 function Format-DeviceModel([string[]]$Values) {
 
-    # Build three tiers, from most specific to most generic
-    $t1 = Format-Set $Values[0,1] # OEMModelNumber, OEMModelBaseBoard
-    $t2 = Format-Set $Values[2,3] # OEMModelSystemFamily, OEMModelSystemVersion
-    $t3 = Format-Set $Values[4,5] # OEMModelSKU, OEMModelBaseBoardVersion
+    # Build tiers, most specific to most generic device info
+    $t1 = Format-Set $Values[0,1] # OEMModelNumber, OEMModelBaseBoard 
+    $t2 = Format-Set $Values[2,3] # OEMModelSystemFamily, OEMModelSystemVersion 
+    $t3 = Format-Set $Values[4] # OEMModelSKU
+    $t4 = Format-Set $Values[5] # OEMModelBaseBoardVersion
 
-    # T1 and T2 always, T3 as fallback
-    $result = if ($t1) { @($t1) + @($t2) } else { @($t3) }
+    # T1 -> T2 -> T3 + T4 as combined fallback 
+    $result = if ($t1) { @($t1) } elseif ($t2) { @($t2) } else { @($t3) + @($t4) }
     $result -join ' - '
 }
 


### PR DESCRIPTION
Fix missing device attributes, as reported by @ericbl in #36 

**Changes**
- Add robust device identification, deduplicate and remove `To Be Filled By O.E.M.` data 
- Add `OSArchitecture` to device header, and prioritize Windows naming scheme, also found in event logs. 
Avoid mixing and allow fast search of correct releases:
  - **Signed** releases: `AMD64`, `ARM`, `ARM64`, `X86`
  - **Unsigned** releases: `X64`, `ARM`, `AARCH64`, `IA32`
- Add `Firmw. Release Date` & resolve `Windows Name` **(7, 8, 8.1, 10, 11)**
----
**Before**
```powershell
20 Mai 2026                                                                                                             
Manufacturer: To Be Filled By O.E.M.
Model: To Be Filled By O.E.M.
BIOS: American Megatrends Inc., P2.50, P2.50, ALASKA - 1072009
Windows version: 22H2 (Build 19045.7291)
```

**New**
```powershell
20 Mai 2026
HW : ASRock - Z87E-ITX - AMD64/X64
FW : American Megatrends Inc. - P2.50 - 11 Jul 2014   # Example 1 (Almost everything To Be Filled By O.E.M.)
OS : Windows 10 - 22H2 (Build 19045.7291)
---------------------------------------------
20 Mai 2026
HW : MSI - Z97 GAMING 5 (MS-7917) - AMD64/X64   
FW : American Megatrends Inc. - V1.13 - 16 Feb 2016   # Example 2 (Half populated, half To Be Filled By O.E.M.)
OS : Windows 11 - 25H2 (Build 26200.8457)
---------------------------------------------
20 Mai 2026
HW : LENOVO - 20L7005QGE - ThinkPad T480s - AMD64/X64
FW : LENOVO - N22ET85W (1.62 ) - 05 Sep 2025          # Example 3 (Fully populated)
OS : Windows 11 - 25H2 (Build 26200.8457)
```
----
Changes above mostly in a script module to assure reusability in `Check Windows State.cmd` etc. Will submit a **separate PR** for a [Colored Windows State (Secure Boot, ESP & SVN overhaul(](https://github.com/cjee21/Check-UEFISecureBootVariables/compare/main...jcoester:Check-UEFISecureBootVariables:remaster), to not dump changed conceptional changes at once.

